### PR TITLE
📝 Add CIS Kubernetes CIS-1.10 for k8s v1.28 - v1.31

### DIFF
--- a/cfg/cis-1.10/config.yaml
+++ b/cfg/cis-1.10/config.yaml
@@ -1,0 +1,2 @@
+---
+## Version-specific settings that override the values in cfg/config.yaml


### PR DESCRIPTION
> **CIS Workbench**: https://workbench.cisecurity.org/benchmarks/17568 **K8s version**: v1.28 to v1.31 **Changelog details in CIS Workbench**: All the checks remain the same as CIS-1.9, only these were changed:
> 
> * 5.2.2 to 5.2.6 and 5.2.9 in policies.yaml have been given a dedicated audit, while remaining `Manual`. Note, the audits are not directly tied to the recommendation (check admission policy), but proactively verifying the running configuration for each container.
> * 5.1.11 in policies.yaml typo correction in title/remediation.
> * 1.2.29 in master.yaml update cipher list to remove insecure ones.