### PR TITLE
fix: required fixes for rke-cis 1.7 / 1.28 / 1.29

### DIFF
--- a/cfg/rke-cis-1.23/master.yaml
+++ b/cfg/rke-cis-1.23/master.yaml
@@ -152,7 +152,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /node/var/lib/etcd
+        audit: stat -c %a /var/lib/etcd
         tests:
           test_items:
             - flag: "700"
@@ -959,15 +959,11 @@ groups:
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"
-              set: true
-            - flag: "--bind-address"
-              set: false
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
@@ -996,15 +992,11 @@ groups:
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"
-              set: true
-            - flag: "--bind-address"
-              set: false
         remediation: |
           Edit the Scheduler pod specification file $schedulerconf
           on the control plane node and ensure the correct value for the --bind-address parameter

--- a/cfg/rke-cis-1.24/node.yaml
+++ b/cfg/rke-cis-1.24/node.yaml
@@ -319,7 +319,7 @@ groups:
         # This is one of those properties that can only be set as a command line argument.
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
-        type: "manual"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
@@ -410,7 +410,7 @@ groups:
 
       - id: 4.2.12
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        type: "manual"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:

--- a/cfg/rke-cis-1.7/master.yaml
+++ b/cfg/rke-cis-1.7/master.yaml
@@ -171,7 +171,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /node/var/lib/etcd
+        audit: stat -c %a /var/lib/etcd
         tests:
           test_items:
             - flag: "700"
@@ -949,14 +949,12 @@ groups:
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"
-            - flag: "--bind-address"
-              set: false
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
@@ -984,14 +982,12 @@ groups:
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"
-            - flag: "--bind-address"
-              set: false
+              set: true
         remediation: |
           Edit the Scheduler pod specification file $schedulerconf
           on the control plane node and ensure the correct value for the --bind-address parameter

--- a/cfg/rke-cis-1.7/node.yaml
+++ b/cfg/rke-cis-1.7/node.yaml
@@ -322,6 +322,7 @@ groups:
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
@@ -426,6 +427,7 @@ groups:
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:


### PR DESCRIPTION
### **User description**
Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Corrected the audit path for etcd data directory permissions.

- Simplified test conditions for `--bind-address` argument in Controller Manager.

- Simplified test conditions for `--bind-address` argument in Scheduler.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>master.yaml</strong><dd><code>Fix audit paths and simplify test conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cfg/rke-cis-1.23/master.yaml

<li>Updated the audit path for etcd data directory permissions.<br> <li> Removed redundant test conditions for <code>--bind-address</code> in Controller <br>Manager.<br> <li> Removed redundant test conditions for <code>--bind-address</code> in Scheduler.


</details>


  </td>
  <td><a href="https://github.com/khulnasoft-lab/kube-bench/pull/150/files#diff-16d0ec4cbd94269e0fa3e5a3007ebc44e0d71a1ac1364f5fcdedc4794207d9da">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

## Summary by Sourcery

Correct the audit path for etcd data directory permissions and simplify test conditions for the `--bind-address` argument in Controller Manager and Scheduler.

Bug Fixes:
- Correct the audit path for the etcd data directory permissions check.
- Simplify the `--bind-address` test conditions for the Controller Manager and Scheduler components by removing redundant checks for unset values and using a direct comparison with "127.0.0.1".