### PR TITLE
Bump golang from 1.23.5 to 1.23.6 to fix CVE-2025-22866

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4 AS build
+FROM golang:1.23.6 AS build
 WORKDIR /go/src/github.com/khulnasoft-lab/kube-bench/
 COPY makefile makefile
 COPY go.mod go.sum ./

--- a/Dockerfile.fips.ubi
+++ b/Dockerfile.fips.ubi
@@ -1,4 +1,4 @@
-FROM golang:1.23.4 AS build
+FROM golang:1.23.6 AS build
 WORKDIR /go/src/github.com/khulnasoft-lab/kube-bench/
 COPY makefile makefile
 COPY go.mod go.sum ./

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM golang:1.23.4 AS build
+FROM golang:1.23.6 AS build
 WORKDIR /go/src/github.com/khulnasoft-lab/kube-bench/
 COPY makefile makefile
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/khulnasoft-lab/kube-bench
 
-go 1.23.4
+go 1.23.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.8


### PR DESCRIPTION
### **User description**
Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated base image in `Dockerfile` to address CVE-2025-22866.

- Upgraded Golang version from 1.23.4 to 1.23.6.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Upgrade Golang version in Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Updated the base image to Golang 1.23.6.<br> <li> Addressed a security vulnerability (CVE-2025-22866).


</details>


  </td>
  <td><a href="https://github.com/khulnasoft-lab/kube-bench/pull/151/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>